### PR TITLE
Add SQLAlchemy dependency

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -30,6 +30,7 @@ If you're unsure, it's safe to skip the API initially. You can always add it lat
 
 - **Modern Python**: Uses Python {{ cookiecutter.python_version }} with type hints and async/await
 - **FastAPI API**: {% if cookiecutter.include_api == 'y' %}Included{% else %}Not included{% endif %} - A modern, fast (high-performance), web framework for building APIs
+- **SQLAlchemy**: Provides a powerful ORM layer for database interactions
 - **Testing**: Pytest with plugins for better testing
 - **Code Quality**: Pre-commit hooks with Black, isort, flake8, and mypy
 - **Containerization**: {% if cookiecutter.use_docker == 'y' %}Dockerfile included{% else %}No Docker support{% endif %}

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "typing-extensions>=4.0.0",
     "python-dotenv>=1.0.0",
+    "sqlalchemy>=2.0",
     {% if cookiecutter.include_api == 'y' %}
     "fastapi>=0.100.0",
     "uvicorn[standard]>=0.23.0",

--- a/{{cookiecutter.project_slug}}/tests/test_sqlalchemy_session.py
+++ b/{{cookiecutter.project_slug}}/tests/test_sqlalchemy_session.py
@@ -1,0 +1,9 @@
+from .conftest import load_project_module
+
+# Load required modules with package context so relative imports succeed
+load_project_module("pkg.config", "config", "__init__.py")
+session_mod = load_project_module("pkg.db.session", "db", "session.py")
+
+def test_sessionlocal_import():
+    assert hasattr(session_mod, "SessionLocal")
+


### PR DESCRIPTION
## Summary
- include `sqlalchemy>=2.0` in dependencies
- document SQLAlchemy in README
- stub SQLAlchemy for tests
- test that SessionLocal can be imported

## Testing
- `pytest -q {{cookiecutter.project_slug}}/tests` *(fails: SyntaxError in test_init.py)*