### PR TITLE
Fix argument parsing in setup_env

### DIFF
--- a/{{cookiecutter.project_slug}}/setup/setup_env.sh
+++ b/{{cookiecutter.project_slug}}/setup/setup_env.sh
@@ -75,25 +75,6 @@ while [[ $# -gt 0 ]]; do
             echo "Unknown parameter: $1"
             exit 1
             ;;
-    escapedone
-
-# Parse command line arguments
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        --no-tests)
-            RUN_TESTS=false
-            shift
-            ;;
-        -h|--help)
-            echo "Usage: $0 [--no-tests]"
-            echo "  --no-tests     Skip running the test suite after setup"
-            echo "  -h, --help     Show this help message"
-            exit 0
-            ;;
-        *)
-            echo "Unknown parameter: $1"
-            exit 1
-            ;;
     esac
 done
 

--- a/{{cookiecutter.project_slug}}/tests/test_setup_env.py
+++ b/{{cookiecutter.project_slug}}/tests/test_setup_env.py
@@ -1,0 +1,31 @@
+import subprocess
+from pathlib import Path
+import pytest
+
+SCRIPT = Path(__file__).parents[1] / "setup" / "setup_env.sh"
+
+@pytest.mark.parametrize("flag", [
+    "--no-tests",
+    "--skip-conda",
+    "--skip-pre-commit",
+    "--skip-lock",
+    "--force",
+    "-v",
+    "--verbose",
+])
+def test_flags_parse_with_help(flag):
+    result = subprocess.run(["bash", str(SCRIPT), flag, "--help"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert result.returncode == 0
+    output = result.stdout.decode() + result.stderr.decode()
+    assert "Usage" in output
+
+def test_help_and_short_help():
+    for flag in ("--help", "-h"):
+        result = subprocess.run(["bash", str(SCRIPT), flag], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        assert result.returncode == 0
+        output = result.stdout.decode() + result.stderr.decode()
+        assert "Usage" in output
+
+def test_unknown_parameter():
+    result = subprocess.run(["bash", str(SCRIPT), "--unknown"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert result.returncode != 0


### PR DESCRIPTION
## Summary
- remove erroneous second argument parsing loop
- close the first loop properly
- test argument parsing via pytest

## Testing
- `pytest {{cookiecutter.project_slug}}/tests/test_setup_env.py`