### PR TITLE
Add dev flag for environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cookiecutter gh:your-org/cookiecutter-python-project
 
 # 3. Set up the Conda env
 cd my_awesome_project
-./setup/setup_env.sh
+./setup/setup_env.sh --dev
 conda activate dev-env
 
 # 4. Dive in!

--- a/{{cookiecutter.project_slug}}/setup/setup_env.sh
+++ b/{{cookiecutter.project_slug}}/setup/setup_env.sh
@@ -26,6 +26,7 @@ SKIP_CONDA=false
 SKIP_PRE_COMMIT=false
 SKIP_TESTS=false
 SKIP_LOCK=false
+DEV_MODE=false
 
 # --- Command line arguments ---
 # Parse command line arguments
@@ -47,6 +48,10 @@ while [[ $# -gt 0 ]]; do
             SKIP_LOCK=true
             shift
             ;;
+        --dev)
+            DEV_MODE=true
+            shift
+            ;;
         --force)
             FORCE=true
             shift
@@ -64,6 +69,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --skip-conda         Skip conda environment setup"
             echo "  --skip-pre-commit    Skip pre-commit installation"
             echo "  --skip-lock          Skip conda-lock generation"
+            echo "  --dev                Use development environment"
             echo "  --force              Force operations that would normally prompt"
             echo "  -v, --verbose        Show more detailed output"
             echo "  -h, --help           Show this help message"
@@ -75,7 +81,8 @@ while [[ $# -gt 0 ]]; do
             echo "Unknown parameter: $1"
             exit 1
             ;;
-    escapedone
+    esac
+done
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -355,7 +362,7 @@ generate_conda_lock() {
     if [ "${SKIP_LOCK}" = true ]; then
         log "info" "Skipping conda-lock generation as requested"
         return 0
-    }
+    fi
     
     section "Generating conda-lock file"
     
@@ -428,7 +435,11 @@ ENV_FILE_DEV="${SCRIPT_DIR}/environment-dev.yml"
 ENV_FILE_BASE="${SCRIPT_DIR}/environment.yml"
 ENV_FILE_TO_USE=""
 
-if [ -f "${ENV_FILE_DEV}" ]; then
+if [ "$DEV_MODE" = true ]; then
+    ENV_FILE_TO_USE="${ENV_FILE_DEV}"
+    ENV_PATH="${ENV_PATH_DEV}"
+    echo -e "${YELLOW}Using development environment file: ${ENV_FILE_TO_USE##*/}${NC}"
+elif [ -f "${ENV_FILE_DEV}" ]; then
     ENV_FILE_TO_USE="${ENV_FILE_DEV}"
     ENV_PATH="${ENV_PATH_DEV}"
     echo -e "${YELLOW}Using development environment file: ${ENV_FILE_TO_USE##*/}${NC}"

--- a/{{cookiecutter.project_slug}}/tests/test_setup_env_script.py
+++ b/{{cookiecutter.project_slug}}/tests/test_setup_env_script.py
@@ -1,0 +1,64 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def make_stub(name: str, directory: Path) -> None:
+    path = directory / name
+    if name == "conda":
+        path.write_text(
+            "#!/bin/sh\n"
+            "if [ \"$1\" = 'info' ] && [ \"$2\" = '--base' ]; then\n"
+            "  echo /tmp\n"
+            "  exit 0\n"
+            "elif [ \"$1\" = 'info' ] && [ \"$2\" = '--envs' ]; then\n"
+            "  echo \"$STUB_ENV_PATH *\"\n"
+            "  exit 0\n"
+            "fi\n"
+            "exit 0\n"
+        )
+    else:
+        path.write_text("#!/bin/sh\nexit 0\n")
+    path.chmod(0o755)
+
+
+def test_dev_flag_selects_dev_env(tmp_path: Path) -> None:
+    # Copy setup scripts
+    setup_dir = tmp_path / "setup"
+    setup_dir.mkdir()
+    project_root = Path(__file__).resolve().parents[2] / "{{cookiecutter.project_slug}}"
+    shutil.copy(project_root / "setup" / "setup_env.sh", setup_dir)
+    shutil.copy(project_root / "setup" / "setup_utils.sh", setup_dir)
+    os.chmod(setup_dir / "setup_env.sh", 0o755)
+    os.chmod(setup_dir / "setup_utils.sh", 0o755)
+
+    # Provide only base environment file
+    (setup_dir / "environment.yml").write_text("name: base\n")
+
+    # Create stub commands to satisfy script dependencies
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for cmd in ["conda", "pip", "pre-commit", "conda-lock", "pytest"]:
+        make_stub(cmd, bin_dir)
+
+    # Minimal files expected by the script
+    etc_dir = Path("/tmp/etc/profile.d")
+    etc_dir.mkdir(parents=True, exist_ok=True)
+    (etc_dir / "conda.sh").write_text("")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["STUB_ENV_PATH"] = str(setup_dir / "dev-env")
+
+    script = setup_dir / "setup_env.sh"
+    result = subprocess.run([
+        str(script),
+        "--dev",
+        "--verbose",
+        "--force",
+    ], cwd=setup_dir, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+    print(result.stdout)
+    assert "Using development environment file" in result.stdout
+


### PR DESCRIPTION
## Summary
- add failing test for `--dev` flag
- implement `--dev` flag for setup script
- document flag usage in README

## Testing
- `pytest -q {{cookiecutter.project_slug}}/tests/test_setup_env_script.py`
- `pytest -q` *(fails: SyntaxError in template tests)*