### PR TITLE
Fix Quickstart env activation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cookiecutter gh:your-org/cookiecutter-python-project
 # 3. Set up the Conda env
 cd my_awesome_project
 ./setup/setup_env.sh --dev
-conda activate dev-env
+conda activate ./dev-env
 
 # 4. Dive in!
 pytest      # runs the placeholder test


### PR DESCRIPTION
## Summary
- update Quickstart docs to activate the dev environment via path

## Testing
- `pytest -q` *(fails: SyntaxError in template tests)*