### PR TITLE
Add conda run usage instructions

### DIFF
--- a/{{cookiecutter.project_slug}}/setup/setup_env.sh
+++ b/{{cookiecutter.project_slug}}/setup/setup_env.sh
@@ -477,11 +477,14 @@ echo -e "\n${GREEN}Activation Instructions:${NC}"
 echo -e "${YELLOW}To activate the environment, run:${NC}"
 echo -e "  conda activate \"${ENV_PATH}\""
 
+echo -e "\n${YELLOW}For scripts and non-interactive usage (recommended for batch jobs/CI):${NC}"
+echo -e "  conda run -p \"${ENV_PATH}\" your_script.py"
+
+echo -e "\n${YELLOW}To run tests:${NC}"
+echo -e "  conda run -p \"${ENV_PATH}\" pytest tests/"
+
 echo -e "\n${YELLOW}Or add this to your shell profile (e.g., .bashrc, .zshrc) for easier activation:${NC}"
 echo -e "  alias activate_project='conda activate \"${ENV_PATH}\"'"
-
-echo -e "\n${YELLOW}To verify the installation, run:${NC}"
-echo -e "  pytest -v --cov=. --cov-report=term-missing"
 
 echo -e "\n${GREEN}Happy coding! 🚀${NC}"
 safe_exit 0

--- a/{{cookiecutter.project_slug}}/tests/test_setup_env_script.py
+++ b/{{cookiecutter.project_slug}}/tests/test_setup_env_script.py
@@ -143,3 +143,35 @@ def test_source_with_run_setup(tmp_path: Path) -> None:
     assert result.returncode == 0
     assert "Environment setup completed" in result.stdout
 
+
+def test_activation_instructions(tmp_path: Path) -> None:
+    """Script should print instructions for conda run usage."""
+    setup_dir = _prepare_scripts(tmp_path)
+    _prepare_environment_files(setup_dir)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _create_stubs(bin_dir)
+
+    etc_dir = Path("/tmp/etc/profile.d")
+    etc_dir.mkdir(parents=True, exist_ok=True)
+    (etc_dir / "conda.sh").write_text("")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["STUB_ENV_PATH"] = str(setup_dir / "dev-env")
+
+    script = setup_dir / "setup_env.sh"
+    result = subprocess.run(
+        [str(script), "--verbose", "--force"],
+        cwd=setup_dir,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    print(result.stdout)
+    assert result.returncode == 0
+    assert "conda run -p" in result.stdout
+


### PR DESCRIPTION
## Summary
- ensure setup script prints instructions for using `conda run`
- cover new instructions with tests

## Testing
- `pytest {{cookiecutter.project_slug}}/tests/test_setup_env_script.py::test_activation_instructions -q`
- `pytest {{cookiecutter.project_slug}}/tests/test_setup_env_script.py -q`
