### PR TITLE
Add clean install option

### DIFF
--- a/{{cookiecutter.project_slug}}/setup/modules/create_environment.sh
+++ b/{{cookiecutter.project_slug}}/setup/modules/create_environment.sh
@@ -6,7 +6,11 @@ create_environment() {
 
     # Check if environment already exists
     if [ -d "${ENV_PATH}" ]; then
-        if [ "${FORCE}" = true ]; then
+        if [ "${CLEAN_INSTALL}" = true ]; then
+            log "warning" "Removing existing environment at ${ENV_PATH} (--clean-install)"
+            rm -rf "${ENV_PATH}"
+            cleanup_nfs_temp_files "${ENV_PATH}"
+        elif [ "${FORCE}" = true ]; then
             log "warning" "Removing existing environment at ${ENV_PATH} (--force)"
             rm -rf "${ENV_PATH}"
         else

--- a/{{cookiecutter.project_slug}}/setup/setup_env.sh
+++ b/{{cookiecutter.project_slug}}/setup/setup_env.sh
@@ -54,6 +54,7 @@ SKIP_PRE_COMMIT=false
 SKIP_TESTS=false
 SKIP_LOCK=false
 DEV_MODE=false
+CLEAN_INSTALL=false
 
 # --- Command line arguments ---
 # Parse command line arguments
@@ -88,6 +89,10 @@ while [[ $# -gt 0 ]]; do
             FORCE=true
             shift
             ;;
+        --clean-install)
+            CLEAN_INSTALL=true
+            shift
+            ;;
         -v|--verbose)
             VERBOSE=true
             shift
@@ -103,6 +108,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --skip-lock          Skip conda-lock generation"
             echo "  --dev                Use development environment"
             echo "  --force              Force operations that would normally prompt"
+            echo "  --clean-install      Remove existing env before creation"
             echo "  --run-setup          Force running setup when sourced"
             echo "  -v, --verbose        Show more detailed output"
             echo "  -h, --help           Show this help message"

--- a/{{cookiecutter.project_slug}}/setup/setup_utils.sh
+++ b/{{cookiecutter.project_slug}}/setup/setup_utils.sh
@@ -51,6 +51,15 @@ run_command_verbose() {
     fi
 }
 
+# Remove stale .nfs files that can prevent directory removal
+cleanup_nfs_temp_files() {
+    local target="$1"
+    if [ -d "$target" ]; then
+        find "$target" -name '.nfs*' -type f -delete 2>/dev/null || true
+        rmdir "$target" 2>/dev/null || true
+    fi
+}
+
 # This makes the script safe to source and prevents it from executing
 # commands if it's run directly, other than defining functions/variables.
 return 0 2>/dev/null || exit 0

--- a/{{cookiecutter.project_slug}}/tests/test_setup_env.py
+++ b/{{cookiecutter.project_slug}}/tests/test_setup_env.py
@@ -9,6 +9,7 @@ SCRIPT = Path(__file__).parents[1] / "setup" / "setup_env.sh"
     "--skip-conda",
     "--skip-pre-commit",
     "--skip-lock",
+    "--clean-install",
     "--force",
     "-v",
     "--verbose",

--- a/{{cookiecutter.project_slug}}/tests/test_setup_env_script.py
+++ b/{{cookiecutter.project_slug}}/tests/test_setup_env_script.py
@@ -16,6 +16,18 @@ def make_stub(name: str, directory: Path) -> None:
             "elif [ \"$1\" = 'info' ] && [ \"$2\" = '--envs' ]; then\n"
             "  echo \"$STUB_ENV_PATH *\"\n"
             "  exit 0\n"
+            "elif [ \"$1\" = 'create' ] || { [ \"$1\" = 'env' ] && [ \"$2\" = 'create' ]; } || { [ \"$1\" = 'env' ] && [ \"$2\" = 'update' ]; }; then\n"
+            "  next=0\n"
+            "  for arg in \"$@\"; do\n"
+            "    if [ \"$next\" = 1 ]; then\n"
+            "      mkdir -p \"$arg\"\n"
+            "      break\n"
+            "    fi\n"
+            "    case $arg in\n"
+            "      -p|--prefix) next=1 ;;\n"
+            "    esac\n"
+            "  done\n"
+            "  exit 0\n"
             "fi\n"
             "exit 0\n"
         )
@@ -213,4 +225,43 @@ def test_idempotent_existing_env(tmp_path: Path) -> None:
     print(result.stdout)
     assert result.returncode == 0
     assert "Updating existing conda environment" in result.stdout
+
+
+def test_clean_install_removes_old_env(tmp_path: Path) -> None:
+    """--clean-install should recreate env and remove .nfs files."""
+    setup_dir = _prepare_scripts(tmp_path)
+    _prepare_environment_files(setup_dir)
+
+    env_dir = setup_dir / "dev-env"
+    env_dir.mkdir()
+    (env_dir / "sentinel").write_text("old")
+    (env_dir / ".nfs123").write_text("temp")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _create_stubs(bin_dir)
+
+    etc_dir = Path("/tmp/etc/profile.d")
+    etc_dir.mkdir(parents=True, exist_ok=True)
+    (etc_dir / "conda.sh").write_text("")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["STUB_ENV_PATH"] = str(env_dir)
+
+    script = setup_dir / "setup_env.sh"
+    result = subprocess.run(
+        [str(script), "--dev", "--verbose", "--clean-install"],
+        cwd=setup_dir,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=5,
+    )
+
+    print(result.stdout)
+    assert result.returncode == 0
+    assert not (env_dir / "sentinel").exists()
+    assert not any(env_dir.glob(".nfs*"))
 


### PR DESCRIPTION
## Summary
- extend CLI to include `--clean-install`
- remove stale `.nfs*` files before re-creating env
- test new flag removes env files
- update help output

## Testing
- `pytest {{cookiecutter.project_slug}}/tests/test_setup_env_script.py -q`
- `pytest {{cookiecutter.project_slug}}/tests/test_setup_env.py -q`
