### PR TITLE
Prevent running setup in active environment

### DIFF
--- a/{{cookiecutter.project_slug}}/setup/setup_env.sh
+++ b/{{cookiecutter.project_slug}}/setup/setup_env.sh
@@ -172,6 +172,13 @@ log() {
     esac
 }
 
+# Abort if the target environment is currently active
+check_not_in_active_env() {
+    if [ -n "${CONDA_PREFIX:-}" ] && [ "$(realpath "${CONDA_PREFIX}")" = "$(realpath "${ENV_PATH}")" ]; then
+        log "error" "The environment at ${ENV_PATH} is currently active. Please deactivate it before running this setup."
+    fi
+}
+
 # --- Main Script ---
 
 if [ "$SOURCED" -eq 1 ] && [ "$RUN_SETUP" -ne 1 ]; then
@@ -182,6 +189,8 @@ fi
 log "info" "Starting ${PROJECT_NAME} environment setup"
 log "debug" "Python version: ${PYTHON_VERSION}"
 log "debug" "Environment path: ${ENV_PATH}"
+
+check_not_in_active_env
 
 # Get the directory of this script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/{{cookiecutter.project_slug}}/tests/test_setup_env_script.py
+++ b/{{cookiecutter.project_slug}}/tests/test_setup_env_script.py
@@ -214,3 +214,36 @@ def test_idempotent_existing_env(tmp_path: Path) -> None:
     assert result.returncode == 0
     assert "Updating existing conda environment" in result.stdout
 
+
+def test_abort_when_env_active(tmp_path: Path) -> None:
+    """Script should error if the target environment is already active."""
+    setup_dir = _prepare_scripts(tmp_path)
+    _prepare_environment_files(setup_dir)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _create_stubs(bin_dir)
+
+    etc_dir = Path("/tmp/etc/profile.d")
+    etc_dir.mkdir(parents=True, exist_ok=True)
+    (etc_dir / "conda.sh").write_text("")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["STUB_ENV_PATH"] = str(setup_dir / "dev-env")
+    env["CONDA_PREFIX"] = str(setup_dir / "dev-env")
+
+    script = setup_dir / "setup_env.sh"
+    result = subprocess.run(
+        [str(script), "--dev", "--verbose"],
+        cwd=setup_dir,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    print(result.stdout)
+    assert result.returncode != 0
+    assert "active" in result.stdout.lower()
+


### PR DESCRIPTION
## Summary
- ensure the environment setup script aborts if run inside the target env
- test the new behaviour in setup_env.sh

## Testing
- `pytest {{cookiecutter.project_slug}}/tests/test_setup_env_script.py -q`