### PR TITLE
Add ensure_conda_lock installer

### DIFF
--- a/{{cookiecutter.project_slug}}/setup/modules/ensure_conda_lock.sh
+++ b/{{cookiecutter.project_slug}}/setup/modules/ensure_conda_lock.sh
@@ -1,0 +1,33 @@
+ensure_conda_lock() {
+    if command -v conda-lock >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if [ -n "${ENV_PATH:-}" ] && command -v conda >/dev/null 2>&1; then
+        if conda run --prefix "${ENV_PATH}" pip install conda-lock >/dev/null 2>&1; then
+            export PATH="${ENV_PATH}/bin:$PATH"
+            command -v conda-lock >/dev/null 2>&1 && return 0
+        fi
+    fi
+
+    if command -v pip >/dev/null 2>&1; then
+        if pip install --user conda-lock >/dev/null 2>&1; then
+            export PATH="$HOME/.local/bin:$PATH"
+            command -v conda-lock >/dev/null 2>&1 && return 0
+        fi
+    fi
+
+    if command -v python >/dev/null 2>&1; then
+        local _tmp_venv
+        _tmp_venv="$(mktemp -d)"
+        if python -m venv "${_tmp_venv}" >/dev/null 2>&1 && \
+           "${_tmp_venv}/bin/pip" install conda-lock >/dev/null 2>&1; then
+            export PATH="${_tmp_venv}/bin:$PATH"
+            command -v conda-lock >/dev/null 2>&1 && return 0
+        fi
+    fi
+
+    return 1
+}
+
+return 0 2>/dev/null || true

--- a/{{cookiecutter.project_slug}}/setup/modules/generate_conda_lock.sh
+++ b/{{cookiecutter.project_slug}}/setup/modules/generate_conda_lock.sh
@@ -6,10 +6,10 @@ generate_conda_lock() {
 
     section "Generating conda-lock file"
 
-    # Check if conda-lock is installed
-    if ! command -v conda-lock &> /dev/null; then
-        log "info" "Installing conda-lock..."
-        run_command_verbose conda install -y -c conda-forge conda-lock
+    # Ensure conda-lock is available
+    if ! ensure_conda_lock; then
+        log "warning" "conda-lock unavailable; skipping lock generation"
+        return 0
     fi
 
     # Determine platform

--- a/{{cookiecutter.project_slug}}/setup/setup_env.sh
+++ b/{{cookiecutter.project_slug}}/setup/setup_env.sh
@@ -133,7 +133,7 @@ source "$UTILS_SCRIPT"
 
 # Source function modules
 MODULES_DIR="${BASH_SOURCE[0]%/*}/modules"
-for module in setup_conda create_environment install_packages setup_pre_commit generate_conda_lock; do
+for module in setup_conda create_environment install_packages setup_pre_commit ensure_conda_lock generate_conda_lock; do
     module_file="${MODULES_DIR}/${module}.sh"
     if [ -f "$module_file" ]; then
         # shellcheck source=/dev/null

--- a/{{cookiecutter.project_slug}}/tests/test_ensure_conda_lock.py
+++ b/{{cookiecutter.project_slug}}/tests/test_ensure_conda_lock.py
@@ -1,0 +1,106 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def _prepare_module(tmp_path: Path) -> Path:
+    project_root = Path(__file__).resolve().parents[2] / "{{cookiecutter.project_slug}}"
+    setup_dir = tmp_path / "setup"
+    setup_dir.mkdir()
+    shutil.copy(project_root / "setup" / "setup_utils.sh", setup_dir)
+    modules_src = project_root / "setup" / "modules"
+    modules_dst = setup_dir / "modules"
+    shutil.copytree(modules_src, modules_dst)
+    return setup_dir
+
+
+def _make_stub(name: str, content: str, directory: Path) -> None:
+    path = directory / name
+    path.write_text(content)
+    path.chmod(0o755)
+
+
+def test_pip_user_fallback(tmp_path: Path) -> None:
+    setup_dir = _prepare_module(tmp_path)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    user_bin = tmp_path / ".local" / "bin"
+    user_bin.mkdir(parents=True)
+
+    _make_stub("conda", "#!/bin/sh\nexit 1\n", bin_dir)
+    pip_content = f"""#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = '--user' ]; then
+    mkdir -p '{user_bin}'
+    echo '#!/bin/sh\nexit 0' > '{user_bin}/conda-lock'
+    chmod +x '{user_bin}/conda-lock'
+    exit 0
+  fi
+done
+exit 1
+"""
+    _make_stub("pip", pip_content, bin_dir)
+    _make_stub("python", "#!/bin/sh\nexit 1\n", bin_dir)
+    mktemp_stub = f"#!/bin/sh\nmkdir -p {tmp_path}/unused\necho {tmp_path}/unused\n"
+    _make_stub("mktemp", mktemp_stub, bin_dir)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["HOME"] = str(tmp_path)
+
+    result = subprocess.run(
+        ["bash", "-c", f"source {setup_dir}/setup_utils.sh; source {setup_dir}/modules/ensure_conda_lock.sh; ensure_conda_lock"],
+        env=env,
+        cwd=setup_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert (user_bin / "conda-lock").exists()
+
+
+def test_virtualenv_fallback(tmp_path: Path) -> None:
+    setup_dir = _prepare_module(tmp_path)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    venv_dir = tmp_path / "venv"
+    venv_dir.mkdir()
+
+    _make_stub("conda", "#!/bin/sh\nexit 1\n", bin_dir)
+    pip_stub = f"""#!/bin/sh
+if [ "$0" = '{venv_dir}/bin/pip' ]; then
+  mkdir -p '{venv_dir}/bin'
+  echo '#!/bin/sh\nexit 0' > '{venv_dir}/bin/conda-lock'
+  chmod +x '{venv_dir}/bin/conda-lock'
+  exit 0
+fi
+exit 1
+"""
+    _make_stub("pip", pip_stub, bin_dir)
+    python_stub = f"""#!/bin/sh
+if [ "$1" = '-m' ] && [ "$2" = 'venv' ]; then
+  mkdir -p '{venv_dir}/bin'
+  cp '{bin_dir}/pip' '{venv_dir}/bin/pip'
+  exit 0
+fi
+exit 1
+"""
+    _make_stub("python", python_stub, bin_dir)
+    mktemp_stub = f"#!/bin/sh\necho {venv_dir}\n"
+    _make_stub("mktemp", mktemp_stub, bin_dir)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+
+    result = subprocess.run(
+        ["bash", "-c", f"source {setup_dir}/setup_utils.sh; source {setup_dir}/modules/ensure_conda_lock.sh; ensure_conda_lock"],
+        env=env,
+        cwd=setup_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert (venv_dir / "bin" / "conda-lock").exists()


### PR DESCRIPTION
## Summary
- add `ensure_conda_lock` module and source it in `setup_env.sh`
- use `ensure_conda_lock` inside `generate_conda_lock.sh`
- test fallback behaviour for user pip and temporary virtualenv installers

## Testing
- `pytest -q {{cookiecutter.project_slug}}/tests/test_ensure_conda_lock.py`