### PR TITLE
Add setup env script tests

### DIFF
--- a/{{cookiecutter.project_slug}}/tests/test_setup_env_script.py
+++ b/{{cookiecutter.project_slug}}/tests/test_setup_env_script.py
@@ -276,10 +276,63 @@ def test_generate_makefile_paths_called(tmp_path: Path) -> None:
         "#!/bin/sh\n" "echo called > \"$(dirname \"$0\")/makefile.paths\"\n"
     )
     os.chmod(gen_script, 0o755)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _create_stubs(bin_dir)
+
+    etc_dir = Path("/tmp/etc/profile.d")
+    etc_dir.mkdir(parents=True, exist_ok=True)
+    (etc_dir / "conda.sh").write_text("")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["STUB_ENV_PATH"] = str(setup_dir / "dev-env")
+
+    script = setup_dir / "setup_env.sh"
+    result = subprocess.run(
+        [str(script), "--verbose", "--force"],
+        cwd=setup_dir,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    print(result.stdout)
+    assert result.returncode == 0
+    assert (scripts_dir / "makefile.paths").exists()
 def test_abort_when_env_active(tmp_path: Path) -> None:
     """Script should error if the target environment is already active."""
     setup_dir = _prepare_scripts(tmp_path)
     _prepare_environment_files(setup_dir)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _create_stubs(bin_dir)
+
+    etc_dir = Path("/tmp/etc/profile.d")
+    etc_dir.mkdir(parents=True, exist_ok=True)
+    (etc_dir / "conda.sh").write_text("")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["STUB_ENV_PATH"] = str(setup_dir / "dev-env")
+    env["CONDA_PREFIX"] = str(setup_dir / "dev-env")
+
+    script = setup_dir / "setup_env.sh"
+    result = subprocess.run(
+        [str(script), "--dev", "--verbose"],
+        cwd=setup_dir,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    print(result.stdout)
+    assert result.returncode != 0
+    assert "active" in result.stdout.lower()
 
 
 def test_clean_install_removes_old_env(tmp_path: Path) -> None:
@@ -306,13 +359,7 @@ def test_clean_install_removes_old_env(tmp_path: Path) -> None:
 
     script = setup_dir / "setup_env.sh"
     result = subprocess.run(
-        [str(script), "--verbose", "--force"],
-    env["CONDA_PREFIX"] = str(setup_dir / "dev-env")
-
-    script = setup_dir / "setup_env.sh"
-    result = subprocess.run(
-        [str(script), "--dev", "--verbose"],
-
+        [str(script), "--dev", "--clean-install", "--verbose"],
         cwd=setup_dir,
         env=env,
         stdout=subprocess.PIPE,
@@ -322,8 +369,8 @@ def test_clean_install_removes_old_env(tmp_path: Path) -> None:
 
     print(result.stdout)
     assert result.returncode == 0
-    assert (scripts_dir / "makefile.paths").exists()
-    assert result.returncode != 0
-    assert "active" in result.stdout.lower()
+    sentinel = env_dir / "sentinel"
+    assert not sentinel.exists() or sentinel.read_text() != "old"
+    assert not list(env_dir.glob(".nfs*"))
 
 


### PR DESCRIPTION
## Summary
- extend setup_env script tests

## Testing
- `pytest -k test_setup_env_script -q` *(fails: SyntaxError in test_init.py)*