### PR TITLE
Update conda initialization

### DIFF
--- a/{{cookiecutter.project_slug}}/setup/modules/setup_conda.sh
+++ b/{{cookiecutter.project_slug}}/setup/modules/setup_conda.sh
@@ -44,8 +44,19 @@ setup_conda() {
             . "${CONDA_PREFIX}/etc/profile.d/conda.sh"
             log "debug" "Sourced conda.sh from ${CONDA_PREFIX}/etc/profile.d/"
         else
-            export PATH="$(conda info --base)/bin:$PATH"
-            log "warning" "Could not find conda.sh, added conda to PATH"
+            local found=""
+            for prefix in "${HOME}/miniconda3" "/usr/local/miniconda" "/opt/conda"; do
+                if [ -f "${prefix}/etc/profile.d/conda.sh" ]; then
+                    . "${prefix}/etc/profile.d/conda.sh"
+                    log "debug" "Sourced conda.sh from ${prefix}/etc/profile.d/"
+                    found=1
+                    break
+                fi
+            done
+            if [ -z "$found" ]; then
+                export PATH="$(conda info --base)/bin:$PATH"
+                log "warning" "Could not find conda.sh, added conda to PATH"
+            fi
         fi
     fi
     unset __conda_setup

--- a/{{cookiecutter.project_slug}}/tests/setup/test_setup_conda_module.py
+++ b/{{cookiecutter.project_slug}}/tests/setup/test_setup_conda_module.py
@@ -57,6 +57,26 @@ def _create_stub_conda(bin_dir: Path, log_file: Path) -> None:
     script.chmod(0o755)
 
 
+def _create_stub_conda_fail_hook(bin_dir: Path, log_file: Path) -> None:
+    """Create a conda stub that fails for the shell hook."""
+    script = bin_dir / "conda"
+    script.write_text(
+        f"#!/bin/sh\n"
+        f"echo conda \"$@\" >> '{log_file}'\n"
+        "if [ \"$1\" = 'shell.bash' ] && [ \"$2\" = 'hook' ]; then\n"
+        "  exit 1\n"
+        "elif [ \"$1\" = 'info' ] && [ \"$2\" = '--base' ]; then\n"
+        "  echo /tmp\n"
+        "  exit 0\n"
+        "elif [ \"$1\" = '--version' ]; then\n"
+        "  echo 'conda 4.0'\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    script.chmod(0o755)
+
+
 def test_setup_conda_uses_module_when_available(tmp_path: Path) -> None:
     log_file = tmp_path / "calls.log"
     bin_dir = tmp_path / "bin"
@@ -127,3 +147,41 @@ def test_try_load_conda_module_fails_when_no_modules(tmp_path: Path) -> None:
     assert result.returncode == 0
     assert status_file.read_text().strip() != "0"
     assert "load" not in log_file.read_text()
+
+
+def test_sources_known_prefix_when_hook_fails(tmp_path: Path) -> None:
+    """setup_conda should source conda.sh from common locations."""
+    log_file = tmp_path / "calls.log"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    _create_stub_conda_fail_hook(bin_dir, log_file)
+
+    setup_dir = _prepare_setup_files(tmp_path)
+
+    home_dir = tmp_path / "home"
+    conda_sh = home_dir / "miniconda3" / "etc" / "profile.d" / "conda.sh"
+    conda_sh.parent.mkdir(parents=True)
+    conda_sh.write_text("echo sourced")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["HOME"] = str(home_dir)
+
+    script = f"""
+        source '{setup_dir}/setup_utils.sh'
+        source '{setup_dir}/setup_conda.sh'
+        log() {{ echo "$@" >> '{log_file}'; }}
+        section() {{ :; }}
+        setup_conda
+    """
+
+    result = subprocess.run([
+        "bash",
+        "-c",
+        script,
+    ], env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+    print(result.stdout)
+    assert result.returncode == 0
+    assert str(conda_sh.parent) in log_file.read_text()


### PR DESCRIPTION
## Summary
- cover sourcing conda.sh when shell hook fails
- source conda.sh from well-known prefixes when available

## Testing
- `pytest tests/setup/test_setup_conda_module.py -q`