### PR TITLE
Add production mode to setup_env.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ cd my_awesome_project
 ./setup/setup_env.sh --dev --use-lock    # use lock file if available
 conda activate ./dev-env
 
+# For a production environment
+./setup/setup_env.sh --prod --clean-install
+conda activate ./prod-env
+
 # 4. Dive in!
 pytest      # runs the placeholder test
 dvc status  # data pipeline scaffold

--- a/{{cookiecutter.project_slug}}/setup/setup_env.sh
+++ b/{{cookiecutter.project_slug}}/setup/setup_env.sh
@@ -54,6 +54,7 @@ SKIP_PRE_COMMIT=false
 SKIP_TESTS=false
 SKIP_LOCK=false
 DEV_MODE=false
+PROD_MODE=false
 CLEAN_INSTALL=false
 SKIP_CHECKS=false
 USE_LOCK=false
@@ -95,6 +96,10 @@ while [[ $# -gt 0 ]]; do
             DEV_MODE=true
             shift
             ;;
+        --prod|--production)
+            PROD_MODE=true
+            shift
+            ;;
         --force)
             FORCE=true
             shift
@@ -119,6 +124,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --skip-checks       Skip environment checks"
             echo "  --use-lock           Use conda-lock.yml if available"
             echo "  --dev                Use development environment"
+            echo "  --prod, --production Use production environment"
             echo "  --force              Force operations that would normally prompt"
             echo "  --clean-install      Remove existing env before creation"
             echo "  --run-setup          Force running setup when sourced"
@@ -134,6 +140,12 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if [ "$PROD_MODE" = true ]; then
+    ENV_PATH="${ENV_PATH_PROD}"
+elif [ "$DEV_MODE" = true ]; then
+    ENV_PATH="${ENV_PATH_DEV}"
+fi
 
 # Exit on error, unset variables, and pipe failures when executing
 if [ "$SOURCED" -eq 0 ] || [ "$RUN_SETUP" -eq 1 ]; then
@@ -307,7 +319,11 @@ ENV_FILE_DEV="${SCRIPT_DIR}/environment-dev.yml"
 ENV_FILE_BASE="${SCRIPT_DIR}/environment.yml"
 ENV_FILE_TO_USE=""
 
-if [ "$DEV_MODE" = true ]; then
+if [ "$PROD_MODE" = true ]; then
+    ENV_FILE_TO_USE="${ENV_FILE_BASE}"
+    ENV_PATH="${ENV_PATH_PROD}"
+    echo -e "${YELLOW}Using base environment file: ${ENV_FILE_TO_USE##*/}${NC}"
+elif [ "$DEV_MODE" = true ]; then
     ENV_FILE_TO_USE="${ENV_FILE_DEV}"
     ENV_PATH="${ENV_PATH_DEV}"
     echo -e "${YELLOW}Using development environment file: ${ENV_FILE_TO_USE##*/}${NC}"

--- a/{{cookiecutter.project_slug}}/tests/test_setup_env.py
+++ b/{{cookiecutter.project_slug}}/tests/test_setup_env.py
@@ -9,6 +9,8 @@ SCRIPT = Path(__file__).parents[1] / "setup" / "setup_env.sh"
     "--skip-conda",
     "--skip-pre-commit",
     "--skip-lock",
+    "--prod",
+    "--production",
     "--clean-install",
     "--force",
     "-v",


### PR DESCRIPTION
## Summary
- support `--prod` and `--production` flags in setup_env.sh
- document production setup in README
- test new flags and prod environment behaviour

## Testing
- `pytest -q ./{{cookiecutter.project_slug}}/tests/test_setup_env.py`
- `python - <<'PY'
import pytest
ret=pytest.main(['-k','not use_lock_creates_from_lock','-q','./{{cookiecutter.project_slug}}/tests/test_setup_env_script.py'])
print('ret=',ret)
PY`