### PR TITLE
feat: add MIT license template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Your Name
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/{{cookiecutter.project_slug}}/LICENSE
+++ b/{{cookiecutter.project_slug}}/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) {{ cookiecutter.time.strftime('%Y') }} {{ cookiecutter.author_name }}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/{{cookiecutter.project_slug}}/tests/test_license_file.py
+++ b/{{cookiecutter.project_slug}}/tests/test_license_file.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+def test_license_files_exist() -> None:
+    """Both repository and template root should contain MIT license."""
+    template_root = Path(__file__).resolve().parents[1]
+    repo_root = template_root.parent
+
+    repo_license = repo_root / "LICENSE"
+    template_license = template_root / "LICENSE"
+
+    assert repo_license.exists(), "LICENSE file missing at repository root"
+    assert template_license.exists(), "LICENSE file missing in template"
+
+    text = template_license.read_text()
+    assert "MIT License" in text


### PR DESCRIPTION
## Summary
- add MIT `LICENSE` file to repository root
- include template `LICENSE` with Jinja placeholders
- test presence of license files

## Testing
- `pytest {{cookiecutter.project_slug}}/tests/test_license_file.py {{cookiecutter.project_slug}}/tests/test_core.py -q`
- `bash {{cookiecutter.project_slug}}/setup/setup_env.sh --dev --no-tests --skip-conda --skip-pre-commit --skip-lock`